### PR TITLE
Fix: Replace "SELECT *" with explicit column names.

### DIFF
--- a/app/controllers/additional_tags_controller.rb
+++ b/app/controllers/additional_tags_controller.rb
@@ -61,11 +61,14 @@ class AdditionalTagsController < ApplicationController
     @tags = ActsAsTaggableOn::Tag.joins("JOIN #{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.taggings_table}" \
                                         " ON #{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.taggings_table}.tag_id =" \
                                         " #{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.tags_table}.id ")
-                                 .select("#{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.tags_table}.*," \
+                                 .select("#{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.tags_table}.id," \
+                                         "#{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.tags_table}.name," \
+                                         "#{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.tags_table}.taggings_count," \
                                          " COUNT(DISTINCT #{ActsAsTaggableOn.taggings_table}.taggable_id) AS count")
                                  .where(id: params[:id] ? [params[:id]] : params[:ids])
                                  .group("#{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.tags_table}.id" \
-                                        ", #{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.tags_table}.name")
+                                        ", #{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.tags_table}.name" \
+                                        ", #{ActiveRecord::Base.connection.quote_table_name ActsAsTaggableOn.tags_table}.taggings_count")
     raise ActiveRecord::RecordNotFound if @tags.empty?
   end
 

--- a/lib/additional_tags/tags.rb
+++ b/lib/additional_tags/tags.rb
@@ -16,14 +16,16 @@ module AdditionalTags
         scope = scope.where("#{TAGGING_TABLE_NAME}.taggable_id!=?", options[:exclude_id]) if options[:exclude_id]
         scope = scope.where(options[:where_field] => options[:where_value]) if options[:where_field].present? && options[:where_value]
 
-        columns = ["#{TAG_TABLE_NAME}.*",
+        columns = ["#{TAG_TABLE_NAME}.id",
+                   "#{TAG_TABLE_NAME}.name",
+                   "#{TAG_TABLE_NAME}.taggings_count",
                    "COUNT(DISTINCT #{TAGGING_TABLE_NAME}.taggable_id) AS count"]
 
         columns << "MIN(#{TAGGING_TABLE_NAME}.created_at) AS last_created" if options[:sort_by] == 'last_created'
 
         scope.select(columns.join(', '))
              .joins(tag_for_joins(klass, options))
-             .group("#{TAG_TABLE_NAME}.id, #{TAG_TABLE_NAME}.name").having('COUNT(*) > 0')
+             .group("#{TAG_TABLE_NAME}.id, #{TAG_TABLE_NAME}.name, #{TAG_TABLE_NAME}.taggings_count").having('COUNT(*) > 0')
              .order(build_order_sql(options[:sort_by], options[:order]))
       end
 


### PR DESCRIPTION
This PR addresses issues with MS SQL Server, whereby "SELECT *" demands that all columns be included within the "GROUP BY" clause. 