### PR TITLE
Change version since it's not compatible with additions version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To install stable version of additional_tags, use
 ```shell
 cd $REDMINE_ROOT
 git clone -b stable https://www.github.com/alphanodes/additionals.git plugins/additionals
-git clone -b 1.0.0 https://www.github.com/alphanodes/additional_tags.git plugins/additional_tags
+git clone -b 1.0.2 https://www.github.com/alphanodes/additional_tags.git plugins/additional_tags
 ```
 
 It is also possible to use stable version as a gem package as an alternative. If you want it, add this to your $REDMINE_ROOT/Gemfile.local:


### PR DESCRIPTION
Base on https://github.com/AlphaNodes/additional_tags/issues/17 , the stable version of additions plugins is 3.0.3 and additional_tags version 1.0.0 only compatible with 3.0.2