### PR TITLE
Fixed 'Add tags'. Added 'Edit tags'

### DIFF
--- a/app/controllers/issue_tags_controller.rb
+++ b/app/controllers/issue_tags_controller.rb
@@ -16,16 +16,15 @@ class IssueTagsController < ApplicationController
                   else
                     @issues.first.tag_list
                   end
-
     @issue_tags.sort!
     @most_used_tags = Issue.available_tags.most_used 10
+    @append = params[:append] == 'true'
   end
 
   def update
     if AdditionalTags.setting?(:active_issue_tags) &&
        User.current.allowed_to?(:edit_issue_tags, @projects.first)
       tags = params[:issue] && params[:issue][:tag_list] ? params[:issue][:tag_list].reject(&:empty?) : []
-
       unless User.current.allowed_to?(:create_issue_tags, @projects.first) || Issue.allowed_tags?(tags)
         flash[:error] = t :notice_failed_to_add_tags
         return
@@ -33,10 +32,12 @@ class IssueTagsController < ApplicationController
 
       Issue.transaction do
         @issues.each do |issue|
-          issue.tag_list = tags
-          issue.save!
+            # add tags added in placeholder for a single/multiple issue or overwrite tags for single issue
+            params[:append] == 'true' ? issue.tag_list << tags : issue.tag_list = tags
+            issue.save!
         end
       end
+
       flash[:notice] = t :notice_tags_added
     else
       flash[:error] = t :notice_failed_to_add_tags

--- a/app/views/context_menus/_issues_tags.html.slim
+++ b/app/views/context_menus/_issues_tags.html.slim
@@ -5,6 +5,12 @@
     ul
       li
         = context_menu_link l(:button_add),
-                            edit_issue_tags_path(ids: @issue_ids, search: params[:search]),
+                            edit_issue_tags_path(ids: @issue_ids, search: params[:search], append: 'true'),
                             remote: true,
                             class: 'icon icon-add'
+      - if @issue_ids.size == 1
+        li
+          = context_menu_link l(:label_edit_for_single_issue_tags),
+                              edit_issue_tags_path(ids: @issue_ids, search: params[:search]),
+                              remote: true,
+                              class: 'icon icon-edit'

--- a/app/views/issue_tags/_edit_modal.html.slim
+++ b/app/views/issue_tags/_edit_modal.html.slim
@@ -1,4 +1,8 @@
-h3.title = l :label_add_tags
+- if @append
+  h3.title = l :label_add_tags
+- else
+  h3.title = l :label_edit_tags_for_single_issue_tags
+  
 
 - if @is_bulk_editing
   h3 = l :label_bulk_edit_selected_issues
@@ -9,12 +13,12 @@ h3.title = l :label_add_tags
   h3
     span = link_to_issue @issues.first
 
-= form_tag issue_tags_path(ids: @issue_ids, search: params[:search]) do
+= form_tag issue_tags_path(ids: @issue_ids, search: params[:search], append: @append.to_s) do
   fieldset.box
     legend = l :field_tags
     #issue_tags
       = additionals_select2_tag 'issue[tag_list]',
-                                options_for_select(@issue_tags.map { |tag| [tag, tag] }, @issue_tags),
+                                options_for_select(@append ? {} : @issue_tags.map { |tag| [tag, tag] }, @issue_tags),
                                 multiple: true,
                                 style: 'width: 100%;',
                                 url: issue_tags_auto_completes_path(project_id: @project),
@@ -24,7 +28,7 @@ h3.title = l :label_add_tags
       = safe_join @most_used_tags.collect { |t| tag.span t.name, class: 'most_used_tag' }, ', '
 
   .buttons
-    = submit_tag l(:button_add), name: nil
+    = submit_tag l(@append ? :button_add : :button_save), name: nil
     '
     = link_to_function l(:button_cancel), 'hideModal(this);'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,8 @@ en:
   label_active_wiki_tags: "Activate wiki tags"
   label_add_tags: "Add tags"
   label_edit_tags: "Edit tags"
+  label_edit_for_single_issue_tags: "Edit (for single issue)"
+  label_edit_tags_for_single_issue_tags: "Edit tags (for single issue)"
   label_manage_tags: "Manage tags"
   label_merge_selected_tags: "Merge selected tags"
   label_open_issues_only: "Display open issues only"

--- a/lib/additional_tags/plugin_version.rb
+++ b/lib/additional_tags/plugin_version.rb
@@ -2,6 +2,6 @@
 
 module AdditionalTags
   module PluginVersion
-    VERSION = '1.0.5' unless defined? VERSION
+    VERSION = '1.0.6' unless defined? VERSION
   end
 end


### PR DESCRIPTION
I made a fix for "Add"  which can cause problems in the current implementation, if we want to add tags for multiple issues.

Example: 
- first issue with tag1 tag2
- second issue with tag3, tag4
- we use "Add" tags and add the tag5
- result => first issue will have tag1,tag2,tag3,tag4,tag5 and second issue same tags as first issue
- in conclusion the "Add" behaves like "Set"
- new implementation will just add tag5 for both issues
- new result => first issue with tag1,tag2,tag5 and second issue tag3,tag4,tag5

New implementation contains "Add" which now behaves like an add and a new menu entry "Edit (for single issue)" which has same behavior like old "Add" implementation but just for a single issue (useful for easy add/delete tags for one issue).

New "Edit (for single issue)" (old "Add" but just for single issue).
![image](https://user-images.githubusercontent.com/48293392/181176624-602edcd5-38f6-421a-bf82-91f5e66c4401.png)
![image](https://user-images.githubusercontent.com/48293392/181177457-ffbb2d35-d474-48f2-ba5e-9b013914cc4b.png)

New "Add".
![image](https://user-images.githubusercontent.com/48293392/181176891-dda78c58-14ec-43e6-828a-465018d48aa6.png)
![image](https://user-images.githubusercontent.com/48293392/181176914-e1848949-5325-42b5-bf69-7b3fc7899abe.png)



