### PR TITLE
Fix removal of tags in issue bulk edit action

### DIFF
--- a/app/views/issues/_tags_bulk_edit.html.slim
+++ b/app/views/issues/_tags_bulk_edit.html.slim
@@ -1,7 +1,8 @@
-- tags = defined?(form) ? form.object.tag_list : []
+- tags = Issue.get_common_tag_list_from_multiple_issues(@issues.map(&:id))
 = additionals_select2_tag 'issue[tag_list]',
                            options_for_select(tags.map { |tag| [tag, tag] }, tags),
                            multiple: true,
                            url: issue_tags_auto_completes_path,
                            placeholder: l(:label_add_tags),
                            tags: true
+= hidden_field_tag 'common_tags', tags.to_s


### PR DESCRIPTION
Removing of tags on the issue bulk edit page currently is broken.

If all selected issues have common tag(s), bulk edit form should display it and allow to remove as it implemented in editing of single issue.

Initially when opening issue bulk edit page it does not render any tags at all. It is possible to add tags in that way but not remove.

PR extracts some logic from the https://github.com/ixti/redmine_tags allowing to remove tags using the issues bulk edit action.