### PR TITLE
Allow the parent project to access the tags of its subprojects

### DIFF
--- a/lib/additional_tags/tags.rb
+++ b/lib/additional_tags/tags.rb
@@ -7,7 +7,7 @@ module AdditionalTags
         user = options[:user].presence || User.current
 
         scope = ActsAsTaggableOn::Tag.where({})
-        scope = scope.where "#{Project.table_name}.id = ?", options[:project] if options[:project]
+        scope = scope.where "#{Project.table_name}.id in (?)", options[:project].self_and_descendants.ids if options[:project]
         if options[:permission]
           scope = scope.where tag_access(options[:permission], user)
         elsif options[:visible_condition]

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -56,10 +56,10 @@ class IssueTest < AdditionalTags::TestCase
   end
 
   test 'available tags should allow list tags of specific project only' do
-    assert_equal 4, Issue.available_tags(project: @project_a).to_a.size
+    assert_equal 5, Issue.available_tags(project: @project_a).to_a.size
     assert_equal 1, Issue.available_tags(project: @project_b).to_a.size
 
-    assert_equal 3, Issue.available_tags(open_issues_only: true, project: @project_a).to_a.size
+    assert_equal 4, Issue.available_tags(open_issues_only: true, project: @project_a).to_a.size
     assert_equal 1, Issue.available_tags(open_issues_only: true, project: @project_b).to_a.size
   end
 
@@ -69,7 +69,7 @@ class IssueTest < AdditionalTags::TestCase
     assert_equal 2, Issue.available_tags(name_like: 's').to_a.size
     assert_equal 2, Issue.available_tags(name_like: 'e').to_a.size
 
-    assert_equal 2, Issue.available_tags(name_like: 'f', project: @project_a).to_a.size
+    assert_equal 3, Issue.available_tags(name_like: 'f', project: @project_a).to_a.size
     assert_equal 0, Issue.available_tags(name_like: 'b', project: @project_a).to_a.size
     assert_equal 1, Issue.available_tags(name_like: 'sec', open_issues_only: true, project: @project_a).to_a.size
     assert_equal 1, Issue.available_tags(name_like: 'fir', open_issues_only: true, project: @project_a).to_a.size
@@ -104,5 +104,19 @@ class IssueTest < AdditionalTags::TestCase
         issue.destroy!
       end
     end
+  end
+
+  def test_available_tags_with_project_option_should_respect_subprojects
+    # tag exists only in subproject
+    Issue.generate! project: @project_b, tag_list: 'im not exist in parent project'
+
+    new_tag = ActsAsTaggableOn::Tag.find_by name: 'im not exist in parent project'
+
+    assert_not_nil new_tag
+
+    # parent project should list all available tags including subprojects
+    assert_includes Issue.available_tags(project: @project_a).to_a, new_tag
+    # subproject
+    assert_includes Issue.available_tags(project: @project_b).to_a, new_tag
   end
 end


### PR DESCRIPTION
The PR fixes issue when some tags don't appear in query filter.

Issue query uses `Issue.available_tags` to get all tags from project, but considering redmine project hierarchy for user it's natural that parent project also has access to all tags of its subprojects in fact it just returns set of tags from the current project and nothing more. If a tag itself doesn't exist in parent project but only in subproject it won't make it in the query filter that was defined in the parent project context.

Consider we have next project tree:
```
Project1
│   Issue1
│
└───Project2
│     Issue2
```

Issue2 has tag `tag2`. Issue1 has no tags.

Go to `Project1` and add tags filter. Select options don't list a `tag2`, because there is no `tag2` in the `Project1` - it resides in `Project2`.
If you manually add `tag2` to the `Issue1` it will be available for filtering and also will show `Issue2` in the result set which is really confusing for the end user.

PR fixes #8 in terms of a query filter. I haven't checked a tag cloud though.