### PR TITLE
Authorization of view tags permission

### DIFF
--- a/lib/additional_tags/patches/issue_patch.rb
+++ b/lib/additional_tags/patches/issue_patch.rb
@@ -68,6 +68,21 @@ module AdditionalTags
 
           ActsAsTaggableOn::TagList.new common_tags
         end
+
+        def load_visible_tags(issues, user = User.current)
+          return if issues.blank?
+
+          available_projects = Project.where(AdditionalTags::Tags.visible_condition(user)).ids
+
+          issues.each do |issue|
+            tags = if available_projects.include? issue.project_id
+                     issue.tags
+                   else
+                     []
+                   end
+            issue.instance_variable_set :@visible_tags, tags
+          end
+        end
       end
 
       module InstanceMethods

--- a/lib/additional_tags/patches/issue_query_patch.rb
+++ b/lib/additional_tags/patches/issue_query_patch.rb
@@ -36,6 +36,14 @@ module AdditionalTags
                                                    values: values,
                                                    permission: :view_issue_tags
         end
+
+        def issues(**options)
+          issues = super
+          return issues unless has_column? :tags
+
+          Issue.load_visible_tags issues
+          issues
+        end
       end
 
       module InstanceMethods

--- a/lib/additional_tags/patches/queries_helper_patch.rb
+++ b/lib/additional_tags/patches/queries_helper_patch.rb
@@ -15,7 +15,7 @@ module AdditionalTags
       module InstanceMethods
         def column_content_with_tags(column, item)
           if column.name == :issue_tags || item.is_a?(Issue) && column.name == :tags
-            additional_tag_links column.value(item), tag_controller: 'issues'
+            additional_tag_links item.instance_variable_get(:@visible_tags), tag_controller: 'issues'
           else
             column_content_without_tags column, item
           end

--- a/lib/additional_tags/tags.rb
+++ b/lib/additional_tags/tags.rb
@@ -3,6 +3,13 @@
 module AdditionalTags
   class Tags
     class << self
+      def visible_condition(user, **options)
+        permission = options[:permission] || :view_issue_tags
+        skip_pre_condition = options[:skip_pre_condition] || true
+
+        tag_access permission, user, skip_pre_condition: skip_pre_condition
+      end
+
       def available_tags(klass, **options)
         user = options[:user].presence || User.current
 

--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -482,28 +482,23 @@ class IssuesControllerTest < AdditionalTags::ControllerTest
     end
   end
 
-  # TODO: find solution to fix it, without n+1 performance problem
   def test_tag_column_should_not_contain_tags_if_user_has_no_permission
-    skip 'known broken test, which should be fixed'
-
     roles(:roles_003).remove_permission! :view_issue_tags
     User.add_to_project users(:users_002), projects(:projects_003), roles(:roles_003)
 
-    with_settings display_subprojects_issues: 1 do
-      with_plugin_settings 'additional_tags', active_issue_tags: 1 do
-        @request.session[:user_id] = 2
-        get :index,
-            params: { project_id: 1,
-                      set_filter: 1,
-                      c: ['tags'],
-                      f: ['tags'] }
+    with_plugin_settings 'additional_tags', active_issue_tags: 1 do
+      @request.session[:user_id] = 2
+      get :index,
+          params: { project_id: 1,
+                    set_filter: 1,
+                    c: ['tags'],
+                    f: ['tags'] }
 
-        assert_response :success
+      assert_response :success
 
-        # User has no permission to view_issue_tags in this project
-        assert_select 'tr#issue-5' do
-          assert_select '.tags a', count: 0
-        end
+      # User has no permission to view_issue_tags in this project
+      assert_select 'tr#issue-5' do
+        assert_select '.tags a', count: 0
       end
     end
   end


### PR DESCRIPTION
In addition to #36

I've tried to achieve strict restriction for issue tags access.

`Issue.available_tags` explicitly sets the permission to `view_issue_tags` instead of `view_issues` (and makes it optional).

Previously, the list of available tags was selected based on the `view_issues` permission. Now it returns a tags scope based on the `view_issue_tags` permissions. The result set is a list of tags which user has access to.

Dashboard block `Issue tags` utilizes `IssueQuery` to get the totals (filter: tags = any). For the `any` condition, filtering by permission `view_issue_tags` has also been added. I changed logic a little bit. Instead of just selecting all issues that have tags now it is split to multiple steps:
* Get a list of projects where user has permission `view_issue_tags`
* Use `Issue.available_tags` to find all visible to user tags
* Based on found tags find all tagged issues
* Then list of issues getting filtered by available projects
And the result is a list of issues that resides in projects where user has permission to view issue tags.

There are still might be some cases where manual authorization is required like https://github.com/dmakurin/additional_tags/commit/9bd17917598d33ea10a3974bd65b2a2b26bb657a#diff-352fd2cfc51782002a317bf279a5cac7b794dcdf1b0c4fb66be5371e224df47fL16

I added tests to cover new behavior and fixed broken ones.
Let me know if this is enough.