### PR TITLE
Don't invoke git in gemspec

### DIFF
--- a/additional_tags.gemspec
+++ b/additional_tags.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/alphanodes/additional_tags'
   spec.license       = 'GPL-2.0'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match %r{^((test|spec|features)/|Gemfile)}
+  spec.files         = Dir['**/*'].reject do |f|
+    f.match %r{^((doc|test)/|Gemfile|package\.json)}
   end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename f }


### PR DESCRIPTION
Redmine plugins are not always installed from git, i.e. the .git directory may not be present, neither the git command. When .git is not present, the following error message is printed when loading the plugin:

    fatal: not a git repository (or any of the parent directories): .git