### PR TITLE
Fix Rails 7.2 compatibility: render text → render plain

### DIFF
--- a/app/controllers/issue_tags_controller.rb
+++ b/app/controllers/issue_tags_controller.rb
@@ -50,6 +50,6 @@ class IssueTagsController < ApplicationController
     Rails.logger.warn "Failed to add tags: #{e.inspect}"
     flash[:error] = t :notice_failed_to_add_tags
   ensure
-    redirect_to_referer_or { render text: 'Tags updated.', layout: true }
+    redirect_to_referer_or { render plain: 'Tags updated.', layout: true }
   end
 end


### PR DESCRIPTION
## Summary
- Fix deprecation warning in Rails 7.2 by replacing `render text:` with `render plain:`

## Details
Rails 7.2 removed support for `render text:`. This causes an `ArgumentError: Unknown keyword: text` error when using the tag update functionality.

## Changes
- `app/controllers/issue_tags_controller.rb`: Changed `render text:` to `render plain:`

## Testing
Tested with Redmine 6.1.1 (Rails 7.2.2)