### PR TITLE
Enable tags on a per project basis.

### DIFF
--- a/app/controllers/additional_tags_controller.rb
+++ b/app/controllers/additional_tags_controller.rb
@@ -15,7 +15,7 @@ class AdditionalTagsController < ApplicationController
 
   # used by api calls
   def index
-    return render_403 unless allow_tags?
+    raise 'tags are not enabled for project' unless allow_tags?
     raise 'type is not provided' if params[:type].blank?
 
     type_info = manageable_tag_columns.detect { |m| m.first.to_s == params[:type] }
@@ -104,9 +104,8 @@ class AdditionalTagsController < ApplicationController
   rescue ActiveRecord::RecordNotFound
     render_404
   end
-  
-  def allow_tags?
-    @project && @project.module_enabled?(:additional_tags)
-  end
 
+  def allow_tags?
+    @project.nil? || @project.module_enabled?(:additional_tags)
+  end
 end

--- a/app/controllers/additional_tags_controller.rb
+++ b/app/controllers/additional_tags_controller.rb
@@ -5,6 +5,8 @@ class AdditionalTagsController < ApplicationController
   before_action :find_tag, only: %i[edit update]
   before_action :bulk_find_tags, only: %i[context_menu merge destroy]
   before_action :set_tag_list_path
+  before_action :find_project_by_project_id, if: -> { params[:project_id] }
+  before_action :authorize, if: -> { @project.present? }
 
   helper :additional_tags_issues
   include AdditionalTagsHelper
@@ -13,6 +15,7 @@ class AdditionalTagsController < ApplicationController
 
   # used by api calls
   def index
+    return render_403 unless allow_tags?
     raise 'type is not provided' if params[:type].blank?
 
     type_info = manageable_tag_columns.detect { |m| m.first.to_s == params[:type] }
@@ -101,4 +104,9 @@ class AdditionalTagsController < ApplicationController
   rescue ActiveRecord::RecordNotFound
     render_404
   end
+  
+  def allow_tags?
+    @project && @project.module_enabled?(:additional_tags)
+  end
+
 end

--- a/app/helpers/additional_tags_issues_helper.rb
+++ b/app/helpers/additional_tags_issues_helper.rb
@@ -4,6 +4,7 @@ module AdditionalTagsIssuesHelper
   # Hacked render_api_custom_values to add plugin values to issue api
   def render_api_custom_values(custom_values, api)
     rc = super
+    return '' unless project.module_enabled?(:additional_tags)
 
     if @issue.present? &&
        (defined?(controller_name) && controller_name == 'issues' && action_name == 'show' || !defined?(controller_name)) &&

--- a/app/helpers/additional_tags_issues_helper.rb
+++ b/app/helpers/additional_tags_issues_helper.rb
@@ -4,11 +4,11 @@ module AdditionalTagsIssuesHelper
   # Hacked render_api_custom_values to add plugin values to issue api
   def render_api_custom_values(custom_values, api)
     rc = super
-    return '' unless project.module_enabled?(:additional_tags)
 
     if @issue.present? &&
        (defined?(controller_name) && controller_name == 'issues' && action_name == 'show' || !defined?(controller_name)) &&
-       AdditionalTags.setting?(:active_issue_tags) && User.current.allowed_to?(:view_issue_tags, @project)
+       AdditionalTags.setting?(:active_issue_tags) && User.current.allowed_to?(:view_issue_tags, @project) &&
+       project.module_enabled?(:additional_tags)
 
       api.array :tags do
         # support tags, which are not saved to database

--- a/app/views/issues/_tags.html.slim
+++ b/app/views/issues/_tags.html.slim
@@ -1,4 +1,4 @@
-- if AdditionalTags.setting?(:active_issue_tags) && User.current.allowed_to?(:view_issue_tags, issue.project)
+- if AdditionalTags.setting?(:active_issue_tags) && User.current.allowed_to?(:view_issue_tags, issue.project) && @project && project.module_enabled?(:additional_tags)
   = render 'additional_tags/tag_list',
            entry: issue,
            show_always: true,

--- a/app/views/projects/settings/_additional_tags.html.erb
+++ b/app/views/projects/settings/_additional_tags.html.erb
@@ -1,0 +1,4 @@
+<p>
+  <%= check_box_tag 'settings[additional_tags_enabled]', 1, @project.additional_tags_enabled? %>
+  <%= label_tag 'settings[additional_tags_enabled]', l(:label_additional_tags_enabled) %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,3 +43,4 @@ en:
   tags_sidebar_simple_cloud: "Simple cloud"
   tags_sort_by_count: "Count"
   tags_sort_by_name: "Name"
+  label_additional_tags_enabled: "Enable Additional Tags"

--- a/db/migrate/20260604000000_add_additional_tags_enabled_to_projects.rb
+++ b/db/migrate/20260604000000_add_additional_tags_enabled_to_projects.rb
@@ -1,0 +1,6 @@
+# db/migrate/20260604000000_add_additional_tags_enabled_to_projects.rb
+class AddAdditionalTagsEnabledToProjects < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :additional_tags_enabled, :boolean, default: true
+  end
+end

--- a/db/migrate/20260604000000_add_additional_tags_enabled_to_projects.rb
+++ b/db/migrate/20260604000000_add_additional_tags_enabled_to_projects.rb
@@ -1,6 +1,5 @@
-# db/migrate/20260604000000_add_additional_tags_enabled_to_projects.rb
 class AddAdditionalTagsEnabledToProjects < ActiveRecord::Migration[6.0]
   def change
-    add_column :projects, :additional_tags_enabled, :boolean, default: true
+    add_column :projects, :additional_tags_enabled, :boolean, default: true, null: false
   end
 end

--- a/init.rb
+++ b/init.rb
@@ -21,10 +21,9 @@ Redmine::Plugin.register :additional_tags do
   end
 
   project_module :additional_tags do
-    permission :view_project_tags, { tags: [:index, :show] }
-    permission :manage_project_tags, { tags: [:new, :create, :edit, :destroy] }
+    permission :view_project_tags, { tags: %i[index, show] }
+    permission :manage_project_tags, { tags: %i[new, create, edit, destroy] }
   end
-
 
   project_module :wiki do
     permission :add_wiki_tags, wiki: %i[update_tags]

--- a/init.rb
+++ b/init.rb
@@ -20,6 +20,12 @@ Redmine::Plugin.register :additional_tags do
     permission :view_issue_tags, {}, read: true
   end
 
+  project_module :additional_tags do
+    permission :view_project_tags, { tags: [:index, :show] }
+    permission :manage_project_tags, { tags: [:new, :create, :edit, :destroy] }
+  end
+
+
   project_module :wiki do
     permission :add_wiki_tags, wiki: %i[update_tags]
   end


### PR DESCRIPTION
Not sure about the error handling.
The use case is that our teams would like certain projects to have tags and others don't and we don't want to clutter up projects with more fields than needed.

First time coding in ruby so I expect there are some errors.
Did test it on a local redmine server. (not production).